### PR TITLE
update label URL field added

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse-feature/feature.xml
+++ b/cobigen-eclipse/cobigen-eclipse-feature/feature.xml
@@ -24,7 +24,7 @@ To the extent CobiGen contains Capgemini proprietary code, non-transferrable use
    </license>
 
    <url>
-      <update label="CobiGen Eclipse Plug-in"/>
+      <update label="CobiGen Eclipse Plug-in" url="https://github.com/devonfw/tools-cobigen"/>
       <discovery label="GitHub Repository" url="https://github.com/devonfw/tools-cobigen"/>
    </url>
 


### PR DESCRIPTION
There was an error at the feature.xml file. Seems that the update label at line 27 must have an url attribute.
