### PR TITLE
Fixing issue #415 duplicated commands on file tree

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/plugin.xml
+++ b/cobigen-eclipse/cobigen-eclipse/plugin.xml
@@ -25,32 +25,90 @@
    </extension>
    <extension
          point="org.eclipse.ui.menus">
-      
       <menuContribution
-        allPopups="false"
-        locationURI="popup:org.eclipse.ui.popup.any?after=additions">
-        <separator
+             allPopups="false"
+             locationURI="popup:org.eclipse.jdt.ui.PackageExplorer">
+          <separator
+                name="com.capgemini.cobigen.eclipseplugin.separator1"
+                visible="true">
+          </separator>
+          <menu
+                label="CobiGen">
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.generate"
+                   label="Generate..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.health_check"
+                   label="Health Check..."
+                   style="push">
+             </command>
+          </menu>
+          <separator
+                name="com.capgemini.cobigen.eclipseplugin.separator2"
+                visible="true">
+          </separator>
+       </menuContribution>
+       <menuContribution
+             allPopups="false"
+             locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu">
+          <separator
+                name="com.capgemini.cobigen.eclipseplugin.separator3"
+                visible="true">
+          </separator>
+          <menu
+                label="CobiGen">
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.generate"
+                   label="Generate..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.health_check"
+                   label="Health Check..."
+                   style="push">
+             </command>
+          </menu>
+          <separator
+                name="com.capgemini.cobigen.eclipseplugin.separator4"
+                visible="true">
+          </separator>
+       </menuContribution>
+       <menuContribution
+             allPopups="false"
+             locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+          <separator
                 name="com.capgemini.cobigen.eclipseplugin.separator5"
                 visible="true">
-        </separator>
-        <menu
-               label="CobiGen">
-            <command
-                  commandId="com.capgemini.cobigen.eclipseplugin.generate"
-                  label="Generate..."
-                  style="push">
-            </command>
-            <command
-                  commandId="com.capgemini.cobigen.eclipseplugin.health_check"
-                  label="Health Check..."
-                  style="push">
-            </command>
-         </menu>
-         <separator
-               name="com.capgemini.cobigen.eclipseplugin.separator6"
-               visible="true">
-         </separator>
-      </menuContribution>
+          </separator>
+          <menu
+                label="CobiGen">
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.generate"
+                   label="Generate..."
+                   style="push">
+             </command>
+             <command
+                   commandId="com.capgemini.cobigen.eclipseplugin.health_check"
+                   label="Health Check..."
+                   style="push">
+             </command>
+             <visibleWhen
+                   checkEnabled="false">
+                   <with variable="selection">
+                      <or>
+                        <instanceof value="org.eclipse.jface.text.ITextSelection"/>
+                        <instanceof value="org.eclipse.wst.sse.ui.StructuredTextEditor$StructuredSelectionProvider$StructuredTextSelection"/>
+                      </or>
+                   </with>
+             </visibleWhen>
+           </menu>
+            <separator
+                name="com.capgemini.cobigen.eclipseplugin.separator6"
+                visible="true">
+            </separator>
+       </menuContribution>
    </extension>
 
 </plugin>


### PR DESCRIPTION
Fixes #415 last commit that duplicated the commands on the file tree.

However, our current problem is that these commands are visible on the Type Hierarchy too as image shows below: 

![image](https://user-images.githubusercontent.com/31688036/33878592-2cef0896-df2c-11e7-8341-535d4b90b03f.png)

I don't know if this behaviour is tolerable, what do you think @maybeec ?

I have tried to make it invisible for the Type Hierarchy, but sadly, there is only a `<visibleWhen>` command:

```xml
<visibleWhen
    checkEnabled="true">
	<with variable="activeMenuSelection">
              <iterate ifEmpty="false">
                <instanceof value="org.eclipse.jdt.internal.core.ResolvedSourceType"/>
            </iterate>
         </with>
</visibleWhen>
``` 