### PR TITLE
#545 Fixing SOAP issue

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/logic/api/to/${variables.entityName}Eto.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/logic/api/to/${variables.entityName}Eto.java.ftl
@@ -10,7 +10,7 @@ import java.util.Set;
 /**
  * Entity transport object of ${variables.entityName}
  */
-public class ${variables.entityName}Eto extends <#if pojo.extendedType.canonicalName=="java.lang.Object" || pojo.extendedType.package!=pojo.package>AbstractEto<#else>${pojo.extendedType.name?replace("Entity","Eto")}</#if> implements ${variables.entityName} {
+public class ${variables.entityName}Eto extends <#if pojo.extendedType.canonicalName=="java.lang.Object" || pojo.extendedType.package!=pojo.package || pojo.extendedType.name == "ApplicationPersistenceEntity">AbstractEto<#else>${pojo.extendedType.name?replace("Entity","Eto")}</#if> implements ${variables.entityName} {
 
 	private static final long serialVersionUID = 1L;
 

--- a/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/general/service/impl/config/ServiceConfig.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/general/service/impl/config/ServiceConfig.java.ftl
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import ${variables.rootPackage}.${variables.component}.service.impl.soap.${variables.component?cap_first}SoapServiceImpl;
 
 import io.oasp.module.rest.service.impl.RestServiceExceptionFacade;
-import io.oasp.module.rest.service.impl.json.ObjectMapperFactory;
+import io.oasp.module.json.common.base.ObjectMapperFactory;
 
 /**
  * {@link Configuration} for (REST or SOAP) services using CXF.


### PR DESCRIPTION
Fixes #545 related to generating REST and SOAP services at the same time.

Changes:

* ServiceConfig was using a deprecated object. We have changed it to fit the new version.
* ETO template needed a change in the logic. If we had an input entity extending from ApplicationPersitenceEntity, then the ETO was generated extending it, which obviously does not make sense since an ETO cannot be persistent.

@devonfw/cobigen
