### PR TITLE
#570 Ionic: Adding attributes in header

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_ionic_client_app/templates/src/pages/${variables.etoName#uncap_first}-list/${variables.etoName#uncap_first}-list.html.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_ionic_client_app/templates/src/pages/${variables.etoName#uncap_first}-list/${variables.etoName#uncap_first}-list.html.ftl
@@ -6,6 +6,21 @@
 -->
 <ion-header>
   <layoutheader Title="${variables.etoName}"></layoutheader>
+  <header class="header-attributes">
+    <span class="header-span item item-block item-md">
+      <div class="item-inner">
+        <div class="input-wrapper">
+          <ion-label class="label label-md">
+            <ion-grid class="header-grid">
+              <ion-row> <#list pojo.fields as field>
+                <ion-col class="crop">{{'${variables.component}.${variables.etoName?uncap_first}.${field.name}'| translate}}</ion-col></#list>
+              </ion-row>
+            </ion-grid>
+          </ion-label>
+        </div>
+      </div>
+    </span>
+  </header>
 </ion-header>
 <ion-content padding>
   <ion-refresher (ionRefresh)="doRefresh($event)">

--- a/cobigen-templates/templates-oasp4j/crud_ionic_client_app/templates/src/pages/${variables.etoName#uncap_first}-list/${variables.etoName#uncap_first}-list.scss.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_ionic_client_app/templates/src/pages/${variables.etoName#uncap_first}-list/${variables.etoName#uncap_first}-list.scss.ftl
@@ -3,6 +3,35 @@
 
 // Put style rules here that you want to apply to ${variables.etoName}.
 
+.header-attributes{
+    background-color: #ddd;
+    padding-left:  7%;
+    padding-right: 9%;
+}
+
+.header-span{
+    background-color: #ddd;
+}
+
+.header-grid {
+    background-color: #dddddd; 
+}
+
+.crop{
+    overflow: hidden;
+    white-space: nowrap; 
+    text-overflow: ellipsis;   
+}
+
+.scroll-content {
+    padding-left: 7%!important;
+    padding-right: 9%!important;
+}
+
+.item-inner{
+    padding-right: 0%!important;
+}
+
 .selected {
     background: color($colors, light, base);
     color : color($colors, dark, base);


### PR DESCRIPTION
Adresses #570.

Implements

* It shows the attribute's names in a header.
* It is responsive, for any kind of size.
* For long names we have used `overflow: hidden` so that the header remains one line.

Example for iPad: 

![ipad](https://user-images.githubusercontent.com/31688036/39767479-293c21f0-52e7-11e8-9b0c-9c6f40eb0dd9.PNG)

Example for Smartphone:

![image](https://user-images.githubusercontent.com/31688036/39767663-91d9f1a6-52e7-11e8-9a03-5399006c7878.png)



@devonfw/cobigen
