### PR TITLE
Project import source change

### DIFF
--- a/oomph/projects/CobiGen.setup
+++ b/oomph/projects/CobiGen.setup
@@ -810,6 +810,16 @@
                 pattern=".*-parent"/>
           </predicate>
         </sourceLocator>
+        <sourceLocator
+            rootFolder="${workspace.location/dev_openapiplugin/cobigen/cobigen-openapiplugin}"
+            locateNestedProjects="true">
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:NamePredicate"
+                pattern=".*-parent"/>
+          </predicate>
+        </sourceLocator>
         <description></description>
       </setupTask>
     </setupTask>


### PR DESCRIPTION
Adresses/Fixes #519.

previous source was set to the master workspace address

I believe there is still an error because in my workspace there is no master folder to import from so i did git clone again.

Implements

* 
* 
* 

@devonfw/cobigen
