### PR TITLE
#551 fixing filtering referenced entities

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/impl/dao/${variables.entityName}DaoImpl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/dataaccess/impl/dao/${variables.entityName}DaoImpl.java.ftl
@@ -58,10 +58,10 @@ public class ${variables.entityName}DaoImpl extends ApplicationDaoImpl<${pojo.na
     	if (${field.name} != null) {
           <#if field.type?ends_with("Entity") && newFieldType=='Long'>
               if(${variables.entityName?lower_case}.get${fieldCapName}() != null) {
-                  query.where(Alias.$(${variables.entityName?lower_case}.get${fieldCapName}Id()).eq(${field.name}));
+                  query.where(Alias.$(${variables.entityName?lower_case}.get${fieldCapName}().getId()).eq(${field.name}));
               }
           <#else>
-              query.where(Alias.$(${variables.entityName?lower_case}.<#if field.type=='boolean'>is${fieldCapName}()<#else>${OaspUtil.resolveIdGetter(field,false,"")}</#if>).eq(${field.name}));
+              query.where(Alias.$(${variables.entityName?lower_case}.<#if field.type=='boolean'>is${fieldCapName}()<#else>${OaspUtil.resolveIdGetter(field, true, pojo.package)}</#if>).eq(${field.name}));
           </#if>  
         <#-- sholzer, 29.05.2017, #259: as above -->  
         }
@@ -81,9 +81,9 @@ public class ${variables.entityName}DaoImpl extends ApplicationDaoImpl<${pojo.na
           <#if !JavaUtil.isCollection(classObject, field.name)>
           case "${field.name}":
             if (OrderDirection.ASC.equals(orderEntry.getDirection())) {
-                query.orderBy(Alias.$(${variables.entityName?lower_case}.get${field.name?cap_first}<#if field.type?ends_with("Entity")>Id</#if>()).asc());
+                query.orderBy(Alias.$(${variables.entityName?lower_case}.get${field.name?cap_first}()<#if field.type?ends_with("Entity")>.getId()</#if>).asc());
             } else {
-                query.orderBy(Alias.$(${variables.entityName?lower_case}.get${field.name?cap_first}<#if field.type?ends_with("Entity")>Id</#if>()).desc());
+                query.orderBy(Alias.$(${variables.entityName?lower_case}.get${field.name?cap_first}()<#if field.type?ends_with("Entity")>.getId()</#if>).desc());
             }   
           break;
           </#if>

--- a/cobigen-templates/templates-oasp4j/src/main/java/utils/OaspUtil.java
+++ b/cobigen-templates/templates-oasp4j/src/main/java/utils/OaspUtil.java
@@ -26,6 +26,20 @@ public class OaspUtil {
     }
 
     /**
+     * Check whether the given 'canonicalType' is declared in the given 'component'
+     *
+     * @param canonicalType
+     *            the type name
+     * @param component
+     *            the component name
+     * @return true iff the canonicalType is inside the given component
+     */
+    public boolean isTypeInComponent(String canonicalType, String component) {
+
+        return canonicalType.matches(String.format("%1$s.[A-Za-z0-9]+(<.*)?", component));
+    }
+
+    /**
      * Determines the ID getter for a given 'field' dependent on whether the getter should access the ID via
      * an object reference or a direct ID getter
      *
@@ -259,7 +273,7 @@ public class OaspUtil {
             } else {
                 suffix = "Id";
             }
-            if (byObjectReference && isEntityInComponent(fieldCType, component)) {
+            if (byObjectReference && isTypeInComponent(fieldCType, component)) {
                 // direct references for Entities in same component, so get id of the object reference
                 suffix = "().getId";
             }

--- a/cobigen-templates/templates-oasp4j/src/test/java/utils/OaspUtilTest.java
+++ b/cobigen-templates/templates-oasp4j/src/test/java/utils/OaspUtilTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import constants.pojo.Field;
 import utils.resources.TestClass;
 import utils.resources.TestEntity;
+import utils.resources.dataaccess.api.DeepEntity;
 
 /**
  * Tests for {@link OaspUtil}
@@ -36,6 +37,35 @@ public class OaspUtilTest {
         field.put(Field.TYPE.toString(), "TestEntity");
         assertEquals("entityId",
             new OaspUtil().resolveIdVariableNameOrSetterGetterSuffix(clazz, field, false, false, ""));
+    }
+
+    /**
+     * Tests {@link OaspUtil#resolveIdGetter(Map,boolean,String)} <br/>
+     * This method is handled in the generation of DAOs. We are testing a concrete case when the input Entity
+     * references another Entity in the same component. Furthermore, verifies that the result is correct even
+     * if the entity name does not end with "Entity".<br/>
+     * <br/>
+     * <b>With</b>
+     * <ul>
+     * <li>Class {@link DeepEntity}</li>
+     * <li>field NAME="testEntityComponent" TYPE="TestEntityComponent", yielding a TestEntityComponent field
+     * </li>
+     * <li>byReference true</li>
+     * <li>component package of the entity</li>
+     */
+    @Test
+    public void testResolveIdGetterEntitySameComponent() throws Exception {
+
+        Map<String, Object> field = new HashMap<>();
+        DeepEntity deepEntity = new DeepEntity();
+        String component = "";
+
+        field.put(Field.NAME.toString(), "testEntityComponent");
+        field.put(Field.CANONICAL_TYPE.toString(), deepEntity.getTestEntityComponent().getClass().getCanonicalName());
+        field.put(Field.TYPE.toString(), deepEntity.getTestEntityComponent().getClass().getTypeName());
+        component = deepEntity.getClass().getPackage().getName();
+
+        assertEquals("getTestEntityComponent().getId()", new OaspUtil().resolveIdGetter(field, true, component));
     }
 
     /**

--- a/cobigen-templates/templates-oasp4j/src/test/java/utils/resources/dataaccess/api/DeepEntity.java
+++ b/cobigen-templates/templates-oasp4j/src/test/java/utils/resources/dataaccess/api/DeepEntity.java
@@ -1,5 +1,14 @@
 package utils.resources.dataaccess.api;
 
-public class DeepEntity{
+public class DeepEntity {
 
+    private TestEntityComponent testEntityComponent = new TestEntityComponent();
+
+    public TestEntityComponent getTestEntityComponent() {
+        return testEntityComponent;
+    }
+
+    public void setTestEntityComponent(TestEntityComponent testEntityComponent) {
+        this.testEntityComponent = testEntityComponent;
+    }
 }

--- a/cobigen-templates/templates-oasp4j/src/test/java/utils/resources/dataaccess/api/TestEntityComponent.java
+++ b/cobigen-templates/templates-oasp4j/src/test/java/utils/resources/dataaccess/api/TestEntityComponent.java
@@ -1,0 +1,8 @@
+package utils.resources.dataaccess.api;
+
+/**
+ * 
+ */
+public class TestEntityComponent {
+
+}


### PR DESCRIPTION
Fixes #551. This pull request enables the retrieval of entities from generated DAOs, in case of having two entities in the same component while Entity A references Entity B. 

Changes:

* Fixed `find${entityName}s(${entityName}SearchCriteriaTo criteria)`
* Fixed `addOrderBy(...)`
* Added new test for trying the method `OaspUtil().resolveIdGetter(field, byObjectReference, component)` when byObjectReference is true.

With the test that @maybeec and me implemented, I have manually checked that the `find...(...)`  as well as `addOrderBy(...)` work correctly. You can see the implemented test here:

```java
    @Test
    public void testSearchIssue() {
        ReportLineSearchCriteriaTo criteria = new ReportLineSearchCriteriaTo();

        PaginationTo pagination = new PaginationTo();
        pagination.setSize(5);
        pagination.setPage(1);
        criteria.setPagination(pagination);
        criteria.setReportId(1L);

        // test do not throw exception
        reportLineDao.findReportLines(criteria).getResult();

        // test do not throw exception
        OrderByTo orderByTo = new OrderByTo();
        OrderDirection orderDirection = OrderDirection.ASC;

        orderByTo.setName("binary");
        orderByTo.setDirection(orderDirection);

        List<OrderByTo> listOrderBy = new ArrayList<OrderByTo>();
        listOrderBy.add(orderByTo);

        ReportSearchCriteriaTo reportCriteria = new ReportSearchCriteriaTo();
        reportCriteria.setPagination(pagination);
        reportCriteria.setActReportLineId(1L);
        reportCriteria.setBinaryId(1L);
        reportCriteria.setSort(listOrderBy);

        reportDao.findReports(reportCriteria);
    }
```

@maybeec would you like this test to be pushed somewhere?

@devonfw/cobigen
