### PR TITLE
added neon freemarker IDE to eclipse

### DIFF
--- a/oomph/products/CobiGenDevelopmentIDE.setup
+++ b/oomph/products/CobiGenDevelopmentIDE.setup
@@ -77,6 +77,9 @@
     <requirement
         name="org.python.pydev.feature.source.feature.group"
         versionRange="[6.3.0,6.4.0)"/>
+    <requirement
+        name="org.jboss.ide.eclipse.freemarker.feature.feature.group"
+        versionRange="[1.5.0,1.6.0)"/>
     <repository
         url="http://fabioz.github.io/startexplorer/update/"/>
     <repository
@@ -93,6 +96,8 @@
         url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/0.9.0.201609252021/"/>
     <repository
         url="http://www.pydev.org/updates"/>
+    <repository
+        url="http://download.jboss.org/jbosstools/neon/stable/updates/"/>
   </setupTask>
   <setupTask
       xsi:type="setup:CompoundTask"


### PR DESCRIPTION


Adresses/Fixes #526 .

Implements

* Added freemarker neon version to the general P2 because the oxygen version is depreciated and neon works apparently as well. https://stackoverflow.com/questions/9385561/freemarker-eclipse-plug-in
* 
* 

@devonfw/cobigen
