### PR TITLE
Fixing erroneous template CRUD logic

### DIFF
--- a/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/${variables.component#cap_first}Impl.java.ftl
+++ b/cobigen-templates/templates-oasp4j/crud_java_server_app/templates/java/${variables.rootPackage}/${variables.component}/logic/impl/${variables.component#cap_first}Impl.java.ftl
@@ -94,9 +94,9 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
     cto.set${variables.entityName?cap_first}(getBeanMapper().map(entity, ${variables.entityName}Eto.class));
     <#list pojo.fields as field>
       <#if field.type?ends_with("Entity")>
-    cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "")}Eto.class));
+    cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "Eto")}.class));
       <#elseif field.type?contains("Entity") && JavaUtil.isCollection(classObject, field.name)>
-    cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListType(field)}Eto.class));
+    cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListArgumentType(field, classObject)}Eto.class));
       </#if>
     </#list>
  
@@ -113,9 +113,9 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
       cto.set${variables.entityName?cap_first}(getBeanMapper().map(entity, ${variables.entityName}Eto.class));
       <#list pojo.fields as field>
         <#if field.type?ends_with("Entity")>
-      cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "")}Eto.class));
+      cto.set${field.name?cap_first}(getBeanMapper().map(entity.get${field.name?cap_first}(), ${field.type?replace("Entity", "Eto")}.class));
         <#elseif field.type?contains("Entity") && JavaUtil.isCollection(classObject, field.name)>
-      cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListType(field)}Eto.class));
+      cto.set${field.name?cap_first}(getBeanMapper().mapList(entity.get${field.name?cap_first}(), ${OaspUtil.getListArgumentType(field, classObject)}Eto.class));
         </#if>
       </#list>
       ctos.add(cto);
@@ -125,6 +125,6 @@ public class ${variables.component?cap_first}Impl extends AbstractComponentFacad
     PaginatedListTo<${variables.entityName}Cto> pagListTo = new PaginatedListTo(ctos, pagResultTo);
     return pagListTo;
   }
-	
+
 
 }

--- a/cobigen-templates/templates-oasp4j/src/main/java/utils/JavaUtil.java
+++ b/cobigen-templates/templates-oasp4j/src/main/java/utils/JavaUtil.java
@@ -3,6 +3,7 @@ package utils;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Collection;
 
 import org.apache.commons.lang3.ClassUtils;
 import org.slf4j.Logger;
@@ -245,8 +246,7 @@ public class JavaUtil {
         if (field == null) {
             return false;
         } else {
-            return field.getType().isAssignableFrom(java.util.List.class)
-                || field.getType().isAssignableFrom(java.util.Set.class);
+            return Collection.class.isAssignableFrom(field.getType());
         }
 
     }

--- a/cobigen-templates/templates-oasp4j/src/main/java/utils/OaspUtil.java
+++ b/cobigen-templates/templates-oasp4j/src/main/java/utils/OaspUtil.java
@@ -338,23 +338,31 @@ public class OaspUtil {
     }
 
     /**
-     * Returns the interface type of the list or set from a field. For example, if we have a List
-     * &lt;SampleEntity&gt; it will return "Sample"
+     * Returns the argument type of the list or set from a field. If the string contains "Entity" it will
+     * remove that part. For example, if we have a List &lt;SampleEntity&gt; it will return "Sample"
      *
      * @param field
      *            the field
-     * @return fieldType interface type of the list
+     * @param pojoClass
+     *            the object class of the Entity that contains the field
+     * @return fieldType argument of the list
+     * @throws SecurityException
+     * @throws NoSuchFieldException
      */
-    public String getListType(Map<String, Object> field) {
+    public String getListArgumentType(Map<String, Object> field, Class<?> pojoClass)
+        throws NoSuchFieldException, SecurityException {
+
+        JavaUtil javaUtil = new JavaUtil();
 
         String fieldType = (String) field.get(Field.TYPE.toString());
         String fieldCType = (String) field.get(Field.CANONICAL_TYPE.toString());
+        String fieldName = (String) field.get(Field.NAME.toString());
 
         if (fieldType.contains("Entity")) {
-            if (fieldCType.startsWith("java.util.List") || fieldCType.startsWith("java.util.Set")) {
+            if (javaUtil.isCollection(pojoClass, fieldName)) {
 
                 fieldType = fieldType.replace("Entity", "");
-                // Regex: Extracts the list type 'List<type>' => type
+                // Regex: Extracts the argument type of the list 'List<type>' => type
                 String regex = "(?<=\\<).+?(?=\\>)";
                 Pattern pattern = Pattern.compile(regex);
                 Matcher regexMatcher = pattern.matcher(fieldType);
@@ -364,7 +372,6 @@ public class OaspUtil {
                 }
             }
         }
-
         return fieldType;
 
     }


### PR DESCRIPTION
This pull request fixes a template that had some typos and other issues. The template is `${variables.component#cap_first}Impl.java` from the `CRUD logic (all in one)` increment.

Changes:

* Fixed typos like lack of brackets in some methods.
* Fixed return type of some methods that were wrong.
* Added an utility method for extracting the interface of Lists and sets.

With the test that @maybeec and me implemented, I have manually checked that the `findEntityCtos(...)` works correctly. You can see the implemented test here:

```java
   @Test
    public void testSearchIssue() {
        ReportLineSearchCriteriaTo criteria = new ReportLineSearchCriteriaTo();
               .
               .
               .
        ReportSearchCriteriaTo reportCriteria = new ReportSearchCriteriaTo();
        reportCriteria.setPagination(pagination);
        reportCriteria.setBinaryObjectId(1L);
        reportCriteria.setSort(listOrderBy);

        assertThat(reportmanagement.findReportCtos(reportCriteria).getResult().size()).isEqualTo(1);

        ReportLineSearchCriteriaTo reportLineCriteria = new ReportLineSearchCriteriaTo();
        reportLineCriteria.setPagination(pagination);
        reportLineCriteria.setReportId(1L);

        assertThat(reportmanagement.findReportLineCtos(reportLineCriteria).getResult().size()).isEqualTo(2);
    }
```

@maybeec I have added one line in the template that I'm not quite sure about, though everything seems to work fine. It is this one:

```java
PaginationResultTo pagResultTo = new PaginationResultTo(criteria.getPagination(), (long) ctos.size());
```

@devonfw/cobigen
