### PR TITLE
Pull Request for issue #603 "tempeng_velocity renamed 'com.capgemini' to 'com.devonfw' for maven central"

### DIFF
--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/pom.xml
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/pom.xml
@@ -6,7 +6,7 @@
   <name>CobiGen - Velocity Template Engine</name>
 
   <parent>
-    <groupId>com.capgemini</groupId>
+    <groupId>com.devonfw</groupId>
     <artifactId>cobigen-tempeng-parent</artifactId>
     <version>dev-SNAPSHOT</version>
   </parent>
@@ -18,7 +18,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.capgemini</groupId>
+      <groupId>com.devonfw</groupId>
       <artifactId>cobigen-core-api</artifactId>
       <version>4.1.0</version>
     </dependency>
@@ -30,19 +30,19 @@
     </dependency>
 
     <dependency>
-      <groupId>com.capgemini</groupId>
+      <groupId>com.devonfw</groupId>
       <artifactId>cobigen-core-test</artifactId>
       <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.capgemini</groupId>
+      <groupId>com.devonfw</groupId>
       <artifactId>cobigen-core</artifactId>
       <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.capgemini</groupId>
+      <groupId>com.devonfw</groupId>
       <artifactId>cobigen-javaplugin</artifactId>
       <version>1.6.0</version>
       <scope>test</scope>

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java-templates/com/devonfw/cobigen/tempeng/velocity/constant/VelocityMetadata.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java-templates/com/devonfw/cobigen/tempeng/velocity/constant/VelocityMetadata.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.constant;
+package com.devonfw.cobigen.tempeng.velocity.constant;
 
 /**
  * Constants extracted from the Velocity pom by velocity-plugin.

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/VelocityTemplateEngine.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/VelocityTemplateEngine.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity;
+package com.devonfw.cobigen.tempeng.velocity;
 
 import java.io.Writer;
 import java.nio.file.Path;
@@ -13,13 +13,13 @@ import org.apache.velocity.exception.VelocityException;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.slf4j.LoggerFactory;
 
-import com.capgemini.cobigen.api.exception.CobiGenRuntimeException;
-import com.capgemini.cobigen.api.extension.TextTemplate;
-import com.capgemini.cobigen.api.extension.TextTemplateEngine;
-import com.capgemini.cobigen.tempeng.velocity.constant.VelocityMetadata;
-import com.capgemini.cobigen.tempeng.velocity.log.LogChuteDelegate;
-import com.capgemini.cobigen.tempeng.velocity.runtime.resources.NullResourceCache;
-import com.capgemini.cobigen.tempeng.velocity.runtime.resources.ResourceManagerDelegate;
+import com.devonfw.cobigen.api.exception.CobiGenRuntimeException;
+import com.devonfw.cobigen.api.extension.TextTemplate;
+import com.devonfw.cobigen.api.extension.TextTemplateEngine;
+import com.devonfw.cobigen.tempeng.velocity.constant.VelocityMetadata;
+import com.devonfw.cobigen.tempeng.velocity.runtime.resources.NullResourceCache;
+import com.devonfw.cobigen.tempeng.velocity.runtime.resources.ResourceManagerDelegate;
+import com.devonfw.cobigen.tempeng.velocity.log.LogChuteDelegate;
 
 /** Template engine for Apache Velocity */
 public class VelocityTemplateEngine implements TextTemplateEngine {

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/log/LogChuteDelegate.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/log/LogChuteDelegate.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.log;
+package com.devonfw.cobigen.tempeng.velocity.log;
 
 import org.apache.velocity.runtime.RuntimeServices;
 import org.apache.velocity.runtime.log.LogChute;

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/runtime/resources/NullResourceCache.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/runtime/resources/NullResourceCache.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.runtime.resources;
+package com.devonfw.cobigen.tempeng.velocity.runtime.resources;
 
 import java.util.Iterator;
 

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/runtime/resources/ResourceManagerDelegate.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/java/com/devonfw/cobigen/tempeng/velocity/runtime/resources/ResourceManagerDelegate.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.runtime.resources;
+package com.devonfw.cobigen.tempeng.velocity.runtime.resources;
 
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/resources/META-INF/services/com.capgemini.cobigen.api.extension.TextTemplateEngine
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/resources/META-INF/services/com.capgemini.cobigen.api.extension.TextTemplateEngine
@@ -1,1 +1,0 @@
-com.capgemini.cobigen.tempeng.velocity.VelocityTemplateEngine

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/resources/META-INF/services/com.devonfw.cobigen.api.extension.TextTemplateEngine
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/main/resources/META-INF/services/com.devonfw.cobigen.api.extension.TextTemplateEngine
@@ -1,0 +1,1 @@
+com.devonfw.cobigen.tempeng.velocity.VelocityTemplateEngine

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/systemtest/VelocityTemplateEngineIntegrationTest.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/systemtest/VelocityTemplateEngineIntegrationTest.java
@@ -1,6 +1,6 @@
-package com.capgemini.cobigen.tempeng.velocity.systemtest;
+package com.devonfw.cobigen.tempeng.velocity.systemtest;
 
-import static com.capgemini.cobigen.test.assertj.CobiGenAsserts.assertThat;
+import static com.devonfw.cobigen.test.assertj.CobiGenAsserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -10,11 +10,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.capgemini.cobigen.api.CobiGen;
-import com.capgemini.cobigen.api.to.GenerationReportTo;
-import com.capgemini.cobigen.api.to.IncrementTo;
-import com.capgemini.cobigen.impl.CobiGenFactory;
-import com.capgemini.cobigen.tempeng.velocity.systemtest.testobjects.Input;
+import com.devonfw.cobigen.api.CobiGen;
+import com.devonfw.cobigen.api.to.GenerationReportTo;
+import com.devonfw.cobigen.api.to.IncrementTo;
+import com.devonfw.cobigen.impl.CobiGenFactory;
+import com.devonfw.cobigen.tempeng.velocity.systemtest.testobjects.Input;
 
 /** Test suite integrating cobigen-core with the velocity template engine. */
 public class VelocityTemplateEngineIntegrationTest {

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/systemtest/testobjects/Input.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/systemtest/testobjects/Input.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.systemtest.testobjects;
+package com.devonfw.cobigen.tempeng.velocity.systemtest.testobjects;
 
 public class Input {
 

--- a/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/unittest/VelocityTemplateEngineTest.java
+++ b/cobigen/cobigen-templateengines/cobigen-tempeng-velocity/src/test/java/com/devonfw/cobigen/tempeng/velocity/unittest/VelocityTemplateEngineTest.java
@@ -1,4 +1,4 @@
-package com.capgemini.cobigen.tempeng.velocity.unittest;
+package com.devonfw.cobigen.tempeng.velocity.unittest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +13,8 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.capgemini.cobigen.api.extension.TextTemplate;
-import com.capgemini.cobigen.tempeng.velocity.VelocityTemplateEngine;
+import com.devonfw.cobigen.api.extension.TextTemplate;
+import com.devonfw.cobigen.tempeng.velocity.VelocityTemplateEngine;
 
 /**
  *


### PR DESCRIPTION
Adresses/Fixes #603 

Implements

renamed 'com.capgemini' to 'com.devonfw' for maven central

@devonfw/cobigen
