### PR TITLE
#603 gh-pages branch refactoring namespace for Maven

### DIFF
--- a/oomph/projects/CobiGen.setup
+++ b/oomph/projects/CobiGen.setup
@@ -108,7 +108,8 @@
         <requirement
             name="com.devonfw.tempeng-velocity"/>
         <requirement
-            name="com.capgemini.cobigen-senchaplugin"/>
+            name="com.capgemini.cobigen-senchaplugin"
+			optional="true"/>
         <requirement
             name="com.devonfw.textmerger"/>
         <requirement


### PR DESCRIPTION
Adresses #603 .

Refactoring namespace of `gh-pages` branch for Maven. Our objective is to make CobiGen OpenSource.

Changes:
* GroupId has been changed from `com.capgemini` to `com.devonfw.cobigen`.
* ArtifactId has been changed from `cobigen-core` to `core`.
* Packages renamed. Therefore, imports have been renamed too.

@devonfw/cobigen
