### PR TITLE
Bugfix/1124 uc logic with cto generation not work properly

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/TemplatesConfigurationReader.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/TemplatesConfigurationReader.java
@@ -287,7 +287,6 @@ public class TemplatesConfigurationReader {
                 if (templates.containsKey(ext.getRef())) {
                     Template template = templates.get(ext.getRef());
                     if (ext.getDestinationPath() != null) {
-                        template.setUnresolvedTemplatePath(ext.getDestinationPath());
                         template.setUnresolvedTargetPath(ext.getDestinationPath());
                     }
                     if (ext.getMergeStrategy() != null) {


### PR DESCRIPTION
Adresses/Fixes #1124 .

Implements

* Remove unnecessary assignment of templatePath to explicit given destinationPath in TemplateConfigurationReader to avoid placing temp files outside of root temp folder
* Passing history map of (original, tmp) to generate method, so that it can use the generated temporary file if existed to merge in the further process

@devonfw/cobigen
