### PR TITLE
fix testRelocate_overlappingTemplateExtensionAndScan

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/TemplatesConfigurationReaderTest.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/TemplatesConfigurationReaderTest.java
@@ -528,7 +528,8 @@ public class TemplatesConfigurationReaderTest extends AbstractUnitTest {
         assertThat(template.getRelativeTemplatePath()).isEqualTo("templates/" + pathWithName);
         assertThat(template.getAbsoluteTemplatePath().toString().replace('\\', '/'))
             .isEqualTo(templatesConfigurationRoot + "templates/" + pathWithName);
-        assertThat(template.getUnresolvedTemplatePath()).isEqualTo(templateName);
+        assertThat(template.getUnresolvedTemplatePath())
+            .isEqualTo(templateScanDestinationPath + scanRelTemplatePath + templateName);
         assertThat(template.getUnresolvedTargetPath()).isEqualTo(templateName);
     }
 


### PR DESCRIPTION
Relates to #1124 

Fix broken test. UnresolvedTemplatePath is now not set to given destination path anymore!

@devonfw/cobigen
