### PR TITLE
Fix unwanted new lines at constructors

### DIFF
--- a/cobigen/cobigen-javaplugin-parent/cobigen-javaplugin/src/main/java/com/devonfw/cobigen/javaplugin/merger/libextension/CustomModelWriter.java
+++ b/cobigen/cobigen-javaplugin-parent/cobigen-javaplugin/src/main/java/com/devonfw/cobigen/javaplugin/merger/libextension/CustomModelWriter.java
@@ -281,7 +281,6 @@ public class CustomModelWriter implements ModelWriter {
         }
 
         buffer.write(" {");
-        buffer.newline();
         if (constructor.getSourceCode() != null) {
             buffer.write(constructor.getSourceCode());
         }


### PR DESCRIPTION
Fixes #1147 

Implements

* com.thoughtworks.qdox adds automatically **a newline** in each constructor when it reads source code -> There is no need to explicit add a new line before anymore

@devonfw/cobigen
