### PR TITLE
Bugfix/1158 external servers does not update properly

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
@@ -493,17 +493,21 @@ public class ExternalProcessHandler {
             if (conn.getResponseCode() < 300) {
 
                 // Check if it is the correct server version
-                BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-                String response = br.readLine();
+                try (InputStreamReader isr = new InputStreamReader(conn.getInputStream());
+                    BufferedReader br = new BufferedReader(isr)) {
+                    String response = br.readLine();
 
-                if (response.equals(processProperties.getServerVersion())) {
-                    return false;
-                }
+                    if (response.equals(processProperties.getServerVersion())) {
+                        return false;
+                    }
 
-                if (response.equals("true")) {
-                    LOG.warn(
-                        "An old version is currently deployed. Please consider deploying the newest version to get the current bug fixes/features");
-                    return false;
+                    if (response.equals("true")) {
+                        LOG.warn(
+                            "An old version is currently deployed. Please consider deploying the newest version to get the current bug fixes/features");
+                        return false;
+                    }
+                } catch (Exception e) {
+                    LOG.info("Reading server version failed");
                 }
 
                 return true;

--- a/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
+++ b/cobigen/cobigen-core-parent/cobigen-core/src/main/java/com/devonfw/cobigen/impl/externalprocess/ExternalProcessHandler.java
@@ -251,6 +251,8 @@ public class ExternalProcessHandler {
             LOG.error("Unable to start the exe/server", e);
         }
 
+        LOG.info("Try to start server at port " + port);
+
         return true;
     }
 
@@ -266,17 +268,6 @@ public class ExternalProcessHandler {
             return true;
         }
 
-        try {
-            if (removeOldVersions(exeName, exeFile.getName())) {
-                LOG.info(
-                    "Cleaning up the external servers folder because something strange was found. Server: " + exeName);
-                Files.deleteIfExists(Paths.get(filePath));
-                return true;
-            }
-        } catch (IOException e) {
-            LOG.error(
-                "Not able to clean externalservers folder, but we will keep the execution as this is not a blocker", e);
-        }
         return false;
     }
 
@@ -386,8 +377,6 @@ public class ExternalProcessHandler {
 
         // Remove tar file
         Files.deleteIfExists(tarPath);
-        // Now we remove old versions of this file
-        removeOldVersions(fileName, currentFileName);
         return filePath;
 
     }
@@ -401,33 +390,6 @@ public class ExternalProcessHandler {
      */
     private String getLastPartOfTarPath(String path) {
         return path.substring(path.lastIndexOf("/") + 1);
-    }
-
-    /**
-     * If found, remove all the files that contain this file name. This is used for removing not needed
-     * versions of the current external process.
-     * @param fileName
-     *            name of the external server (e.g. "nestserver")
-     * @param currentFileName
-     *            name of the current external server including the version number and its extension (e.g.
-     *            "nestserver-1.0.7.exe")
-     * @return true if any file was removed
-     * @throws IOException
-     *             {@link IOException} occurred while removing the file
-     */
-    private Boolean removeOldVersions(String fileName, String currentFileName) throws IOException {
-        File folder = new File(ExternalProcessConstants.EXTERNAL_PROCESS_FOLDER.toString());
-        File[] listOfFiles = folder.listFiles();
-        Boolean somethingWasRemoved = false;
-
-        for (File currFile : listOfFiles) {
-            if (currFile.getName().contains(fileName) && !currFile.getName().equals(currentFileName)) {
-                // Remove old version of file
-                Files.deleteIfExists(currFile.toPath());
-                somethingWasRemoved = true;
-            }
-        }
-        return somethingWasRemoved;
     }
 
     /**


### PR DESCRIPTION
Fixes #1158 

Implements

* Do not remove old external servers
* fix acquirePort in initializeConnection() by calling startConnection() again to have new port in url 
* Add check if the correct version is currently deployed

@devonfw/cobigen
