### PR TITLE
Adjusted core snapshot version due to a planned bugfix release

### DIFF
--- a/cobigen/cobigen-core-parent/pom.xml
+++ b/cobigen/cobigen-core-parent/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <properties>
-    <cobigencore.version>6.2.0-SNAPSHOT</cobigencore.version>
+    <cobigencore.version>6.1.2-SNAPSHOT</cobigencore.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
As there will be a bugfix release in the near future, the next released version of the core will be 6.1.2 instead of 6.2.0.
