### PR TITLE
changed systemtest dependencies to latest versions

### DIFF
--- a/cobigen/cobigen-core-parent/cobigen-core-systemtest/pom.xml
+++ b/cobigen/cobigen-core-parent/cobigen-core-systemtest/pom.xml
@@ -26,13 +26,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tempeng-freemarker</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <version>7.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaplugin</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <version>7.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Adresses #1286.

Changed the dependencies of the freemarker engine and javaplugin to the latest version.