### PR TITLE
Remove or Replace all mentions of Bintray

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <java.version>1.8</java.version>
     <tycho.version>1.6.0</tycho.version>
     <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
-    <bintray.url>https://dl.bintray.com/devonfw</bintray.url>
-    <!-- bintray.repository needs to be set by cmd and needs to be one of https://bintray.com/devonfw repositories -->
-    <bintray.repository.url>${bintray.url}/${bintray.repository}</bintray.repository.url>
+    <updatesite.url>https://devonfw.com/cobigen/updatesite</updatesite.url>
+    <!-- updatesite.repository needs to be set by cmd and needs to be one of  repositories -->
+    <updatesite.repository.url>${updatesite.url}/${updatesite.repository}</updatesite.repository.url>
     <p2.repository.build.dir>${project.build.directory}${file.separator}repository</p2.repository.build.dir>
     <p2.repository.upload.dir>${project.build.directory}${file.separator}repository-upload</p2.repository.upload.dir>
     <p2.repository.upload.dir.plugin>${p2.repository.upload.dir}/cobigen-${project.artifactId}</p2.repository.upload.dir.plugin>
@@ -165,7 +165,7 @@
         </executions>
       </plugin>
 	  <!-- plugins from profile -->
-	  <!-- sets ${qualifiedVersion} for bintray upload -->
+	  <!-- sets ${qualifiedVersion} for upload to update site -->
 	  <plugin>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-packaging-plugin</artifactId>
@@ -365,12 +365,12 @@
         </plugins>
       </build>
     </profile>
-    <!-- Bintray update site -->
+    <!-- Update site -->
     <profile>
-      <id>p2-upload-bintray</id>
+      <id>p2-upload-updatesite</id>
       <activation>
         <property>
-          <name>bintray.repository</name>
+          <name>updatesite.repository</name>
         </property>
         <file>
           <!-- It is not possible to check for directories. Therefore workaround: check for existing file in folder -->
@@ -394,7 +394,7 @@
               <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
             </configuration>
           </plugin>
-          <!-- sets ${qualifiedVersion} for bintray upload -->
+          <!-- sets ${qualifiedVersion} for updatesite upload -->
           <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-packaging-plugin</artifactId>
@@ -444,35 +444,14 @@
                   <goal>download</goal>
                 </goals>
                 <configuration>
-                  <url>${bintray.repository.url}</url>
+                  <url>${updatesite.repository.url}</url>
                   <includes>artifacts.jar,content.jar</includes>
                   <toDir>${p2.repository.upload.dir.plugin}</toDir>
-                  <serverId>bintray-repo</serverId>
+                  <serverId>updatesite-repo</serverId>
                 </configuration>
               </execution>
             </executions>
           </plugin>
-<!--          <plugin>
-            <groupId>com.carrotgarden.maven</groupId>
-            <artifactId>bintray-maven-plugin</artifactId>
-            <version>1.5.20191113165555</version>
-            <configuration>
-              <skip>false</skip>
-              <subject>devonfw</subject>
-              <repository>${bintray.repository}</repository>
-              <serverId>bintray-repo</serverId>
-              <bintrayVersion>${qualifiedVersion}</bintrayVersion>
-              <sourceFolder>${p2.repository.upload.dir.plugin}</sourceFolder>
-              <targetFolder>cobigen-${project.artifactId}</targetFolder>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>upload</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>-->
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Adresses #1318.

As Bintray is discontinued and we changed to a different type of updatesite (gh-pages), we should remove all mentions of Bintray and replace them where applicable

Implements

* Mentions of Bintray and relevant plugin removed/replaced in master pom

@devonfw/cobigen
