### PR TITLE
#1387 fixed classpath regex parsing issue

### DIFF
--- a/cobigen-cli/cli/src/main/assembly/resources/bin/cg
+++ b/cobigen-cli/cli/src/main/assembly/resources/bin/cg
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIB_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../lib" && pwd )"
 if [ -z "$1" ]; then
-    java -cp "$LIB_DIR/*" com.devonfw.cobigen.cli.CobiGenCLI -help
+    java -cp "$(printf %s: $LIB_DIR/*.jar)" -help
 else
-    java -cp "$LIB_DIR/*" com.devonfw.cobigen.cli.CobiGenCLI "$@"
+    java -cp "$(printf %s: $LIB_DIR/*.jar)" com.devonfw.cobigen.cli.CobiGenCLI "$@"
 fi

--- a/cobigen-cli/cli/src/main/assembly/resources/bin/cg
+++ b/cobigen-cli/cli/src/main/assembly/resources/bin/cg
@@ -1,7 +1,10 @@
 #!/bin/bash
+# -cp "$LIB_DIR/*" is not working, please don't change this back!
+# Check: https://github.com/devonfw/cobigen/issues/1387
+# and https://stackoverflow.com/a/219801
 LIB_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../lib" && pwd )"
 if [ -z "$1" ]; then
-    java -cp "$(printf %s: $LIB_DIR/*.jar)" -help
+    java -cp "$(printf %s: $LIB_DIR/*.jar)" com.devonfw.cobigen.cli.CobiGenCLI -help
 else
     java -cp "$(printf %s: $LIB_DIR/*.jar)" com.devonfw.cobigen.cli.CobiGenCLI "$@"
 fi


### PR DESCRIPTION
Fixes issue with classpath parsing on Windows git bash.

Fixes #1387 .

### Related to:
https://github.com/devonfw/ide/issues/598

@devonfw/cobigen
