### PR TITLE
Fix Eclipse plug-in tests on github actions

### DIFF
--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run Core Systemtest
         shell: bash
         run: |
-          mvn test -f cobigen/cobigen-core-systemtest -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          mvn test -f cobigen/cobigen-core-systemtest -Pp2-build -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   build-and-test-eclipse-plugin:
     needs: build-plugins-p2

--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run Core Systemtest
         shell: bash
         run: |
-          mvn test -f cobigen/cobigen-core-systemtest -Pp2-build -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          mvn test -f cobigen/cobigen-core-systemtest -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   build-and-test-eclipse-plugin:
     needs: build-plugins-p2
@@ -235,7 +235,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.5
         with:
           run: |
-            mvn install -f cobigen-eclipse -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            mvn install -f cobigen-eclipse -Pp2-build -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   build-and-test-maven-plugin:
     needs: build-and-test-plugins


### PR DESCRIPTION
Fixes issues with Eclipse Plug-In E2E tests on github actions.

Current fix needs to be discussed first as it takes about 15 minutes for the github actions worker to complete the Eclipse tests now.

@devonfw/cobigen
