### PR TITLE
#1246 bug seems to be fixed, just adapted the test to make sure

### DIFF
--- a/cobigen-plugins/cobigen-propertyplugin/src/test/java/com/devonfw/cobigen/propertyplugin/PropertyMergerTest.java
+++ b/cobigen-plugins/cobigen-propertyplugin/src/test/java/com/devonfw/cobigen/propertyplugin/PropertyMergerTest.java
@@ -34,8 +34,7 @@ public class PropertyMergerTest extends TestCase {
         IOUtils.toString(new FileReader(new File(testFileRootPath + "Name.ftl"))), "UTF-8");
     assertThat(mergedPropFile).contains("NachNameOverride");
     assertThat(mergedPropFile).doesNotContain("nachNameOriginal");
-    assertThat(mergedPropFile).contains("firstName");
-    assertThat(mergedPropFile).contains("lastName");
+    assertThat(mergedPropFile).containsSequence("lastName", "firstName");
   }
 
   /**


### PR DESCRIPTION
Adresses/Fixes #1246.

Implements
check if the order of the properties is correct instead of just checking for appearance.

@devonfw/cobigen
