### PR TITLE
#1434 added repeatable prompt for output path of OpenApi generation

### DIFF
--- a/cobigen-cli/cli/pom.xml
+++ b/cobigen-cli/cli/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>4.5.1</version>
+      <version>4.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/GenerateCommand.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/GenerateCommand.java
@@ -151,8 +151,8 @@ public class GenerateCommand extends CommandCommons {
           && MavenUtil.getProjectRoot(inputFile.toPath(), false) == null) {
 
         LOG.info(
-            "No ouput directory was found. Please specify an ouput path or just press enter to generate your files to this directory: {}",
-            inputFile.getAbsoluteFile().getParent().toString());
+            "No output directory was found. Please specify an output path or just press enter to generate your files to this directory: {}",
+            inputFile.getAbsoluteFile().getParent());
 
         String userInput = getUserInput();
 

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/GenerateCommand.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/GenerateCommand.java
@@ -145,12 +145,6 @@ public class GenerateCommand extends CommandCommons {
         LOG.info(
             "Did not detect the input as part of a maven project, the root directory of the maven project was not found.");
 
-        // cancels with an error if more than one input file was provided
-        if (this.inputFiles.size() > 1) {
-          LOG.error(
-              "As multiple input files were provided, setting an automatic output path is not possible. Cancelling...");
-          System.exit(1);
-        }
         LOG.info("Would you like to take '{}' as a root directory for output generation? \n"
             + "type yes/y to continue or no/n to cancel (or hit return for yes).", System.getProperty("user.dir"));
 

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/UpdateCommand.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/commands/UpdateCommand.java
@@ -22,6 +22,7 @@ import com.devonfw.cobigen.cli.CobiGenCLI;
 import com.devonfw.cobigen.cli.constants.MessagesConstants;
 import com.devonfw.cobigen.cli.utils.CobiGenUtils;
 import com.devonfw.cobigen.cli.utils.PluginUpdateUtil;
+import com.devonfw.cobigen.cli.utils.ValidationUtils;
 import com.devonfw.cobigen.impl.config.constant.MavenMetadata;
 
 import picocli.CommandLine.Command;
@@ -103,7 +104,7 @@ public class UpdateCommand extends CommandCommons {
    */
   private void userInputPluginSelection(ArrayList<String> userInputPluginForUpdate) {
 
-    for (String userArtifact : GenerateCommand.getUserInput().split(",")) {
+    for (String userArtifact : ValidationUtils.getUserInput().split(",")) {
       userInputPluginForUpdate.add(userArtifact);
     }
   }

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/exceptions/UserAbortException.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/exceptions/UserAbortException.java
@@ -1,0 +1,15 @@
+package com.devonfw.cobigen.cli.exceptions;
+
+import com.devonfw.cobigen.api.exception.CobiGenCancellationException;
+
+/**
+ * Exception is thrown if the generation process was cancelled by the user
+ */
+public class UserAbortException extends CobiGenCancellationException {
+
+  /**
+   * Default serial version UID.
+   */
+  private static final long serialVersionUID = 1L;
+
+}

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ParsingUtils.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ParsingUtils.java
@@ -1,7 +1,6 @@
 
 package com.devonfw.cobigen.cli.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -39,13 +38,13 @@ public class ParsingUtils {
    * @return true only if the parsed file exists, false otherwise
    *
    */
-  public static boolean parseRelativePath(List<File> inputFiles, File inputFile, int index) {
+  public static boolean parseRelativePath(List<Path> inputFiles, Path inputFile, int index) {
 
     try {
       Path inputFilePath = Paths.get(System.getProperty("user.dir"), inputFile.toString());
 
       if (inputFilePath.toFile().exists()) {
-        inputFiles.set(index, inputFilePath.toFile());
+        inputFiles.set(index, inputFilePath);
         return true;
       }
     } catch (InvalidPathException e) {

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ValidationUtils.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ValidationUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.InputMismatchException;
+import java.util.Scanner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,11 @@ public final class ValidationUtils {
    * Logger useful for printing information
    */
   private static Logger LOG = LoggerFactory.getLogger(CobiGenCLI.class);
+
+  /**
+   * Used for getting users input
+   */
+  private static final Scanner inputReader = new Scanner(System.in);
 
   /**
    * Validating user input file is correct or not. We check if file exists and it can be read
@@ -114,6 +120,47 @@ public final class ValidationUtils {
           + "More info here https://github.com/devonfw/cobigen/wiki/cobigen-openapiplugin#usage");
     }
     throw new InputMismatchException("Your input file is invalid.");
+  }
+
+  /**
+   * Asks the user for input and returns the value
+   *
+   * @return String containing the user input
+   */
+  public static String getUserInput() {
+
+    String userInput = "";
+    userInput = inputReader.nextLine();
+    return userInput;
+  }
+
+  /**
+   * Creates a simple looping yes/no prompt with customizable valid/invalid/cancel messages
+   *
+   * @param validInputMessage String for a message in case of a valid input
+   * @param invalidInputMessage String for a message in case of an invalid input
+   * @param cancelMessage String for a message in case the user cancelled the process
+   * @return boolean decision of the user
+   */
+  public static boolean yesNoPrompt(String validInputMessage, String invalidInputMessage, String cancelMessage) {
+
+    while (true) {
+      String userInput = getUserInput();
+      switch (userInput) {
+        case "yes":
+        case "y":
+        case "":
+          LOG.info(validInputMessage);
+          return true;
+        case "no":
+        case "n":
+          LOG.info(cancelMessage);
+          return false;
+        default:
+          LOG.info(invalidInputMessage);
+          break;
+      }
+    }
   }
 
 }

--- a/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ValidationUtils.java
+++ b/cobigen-cli/cli/src/main/java/com/devonfw/cobigen/cli/utils/ValidationUtils.java
@@ -1,6 +1,8 @@
 package com.devonfw.cobigen.cli.utils;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.InputMismatchException;
 
 import org.slf4j.Logger;
@@ -53,10 +55,10 @@ public final class ValidationUtils {
    *
    * @return true if it is a valid output root path
    */
-  public static boolean isOutputRootPathValid(File outputRootPath) {
+  public static boolean isOutputRootPathValid(Path outputRootPath) {
 
     // As outputRootPath is an optional parameter, it means that it can be null
-    if (outputRootPath == null || outputRootPath.exists()) {
+    if (outputRootPath == null || Files.exists(outputRootPath)) {
       return true;
     } else {
       LOG.error("Your <outputRootPath> '{}' does not exist, please use a valid path.", outputRootPath);
@@ -100,10 +102,10 @@ public final class ValidationUtils {
    * @param isJavaInput true when input file is Java
    * @param isOpenApiInput true when input file is OpenAPI
    */
-  public static void throwNoTriggersMatched(File inputFile, boolean isJavaInput, boolean isOpenApiInput) {
+  public static void throwNoTriggersMatched(Path inputFile, boolean isJavaInput, boolean isOpenApiInput) {
 
     LOG.error("Your input file '{}' is not valid as input for any generation purpose. It does not match any trigger.",
-        inputFile.getName());
+        inputFile.getFileName());
     if (isJavaInput) {
       LOG.error("Check that your Java input file is following devon4j naming convention. "
           + "Explained on https://devonfw.com/website/pages/docs/devon4j.asciidoc_coding-conventions.html");

--- a/release.sh
+++ b/release.sh
@@ -162,8 +162,9 @@ then
   exit 0
 else
   log_step "Publish Release"
-  doRunCommand "git push --tags"
-  doRunCommand "cd ../gh-pages && git push && cd $SCRIPT_PATH"
+  doRunCommand "git push origin master"
+  doRunCommand "git push origin v$NEW_VERSION"
+  doRunCommand "cd ../gh-pages && git push origin master && cd $SCRIPT_PATH"
   doRunCommand "mvn nexus-staging:release $MVN_SETTINGS -f cobigen $DEBUG $BATCH_MODE"
   doRunCommand "mvn nexus-staging:release $MVN_SETTINGS -f cobigen-plugins $DEBUG $BATCH_MODE"
   doRunCommand "mvn nexus-staging:release $MVN_SETTINGS -f cobigen-cli $DEBUG $BATCH_MODE"


### PR DESCRIPTION
Added repeatable prompt for output path of OpenApi generation if automatic detection of output path failed (if user just hits enter, the parent directory of the inputfile gets used as output directory)

set outputRootPath to absolute path in setOutputRootPath method

Adresses/Fixes #1434 .

Implements

* 
* 
* 

@devonfw/cobigen
