### PR TITLE
Fix for GenerateCommandTest

### DIFF
--- a/cobigen-cli/cli-systemtest/src/test/java/com/devonfw/cobigen/cli/systemtest/GenerateCommandTest.java
+++ b/cobigen-cli/cli-systemtest/src/test/java/com/devonfw/cobigen/cli/systemtest/GenerateCommandTest.java
@@ -290,7 +290,7 @@ public class GenerateCommandTest extends AbstractCliTest {
     args[2] = "--out";
     args[3] = outputRootPath.toFile().getAbsolutePath();
     args[4] = "--increments";
-    args[5] = "15";
+    args[5] = "OpenAPI_Docs";
 
     execute(args, true);
 


### PR DESCRIPTION
Implements

* Changed the increment in the GenerateCommandTest. The test failed because the increment number does not match with the new folder structure
