### PR TITLE
#1532 fixed HealthCheck not being able to handle a conflict with the old and new configuration

### DIFF
--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ExceptionHandler.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ExceptionHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.devonfw.cobigen.api.exception.CobiGenRuntimeException;
+import com.devonfw.cobigen.api.exception.ConfigurationConflictException;
 import com.devonfw.cobigen.api.exception.InvalidConfigurationException;
 import com.devonfw.cobigen.eclipse.common.constants.external.ResourceConstants;
 import com.devonfw.cobigen.eclipse.common.exceptions.GeneratorCreationException;
@@ -36,6 +37,9 @@ public class ExceptionHandler {
     } else if (InvalidConfigurationException.class.isAssignableFrom(e.getClass())) {
       LOG.warn("Invalid configuration.", e);
       openInvalidConfigurationErrorDialog((InvalidConfigurationException) e);
+    } else if (ConfigurationConflictException.class.isAssignableFrom(e.getClass())) {
+      LOG.warn("Conflicted configuration.", e);
+      openInvalidConfigurationErrorDialog((ConfigurationConflictException) e);
     } else if (GeneratorProjectNotExistentException.class.isAssignableFrom(e.getClass())) {
       LOG.error(
           "The project '{}' containing the configuration and templates is currently not existent. Please create one or check it out from SVN as stated in the user documentation.",

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ExceptionHandler.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/common/tools/ExceptionHandler.java
@@ -38,7 +38,6 @@ public class ExceptionHandler {
       LOG.warn("Invalid configuration.", e);
       openInvalidConfigurationErrorDialog((InvalidConfigurationException) e);
     } else if (ConfigurationConflictException.class.isAssignableFrom(e.getClass())) {
-      LOG.warn("Conflicted configuration.", e);
       openInvalidConfigurationErrorDialog((ConfigurationConflictException) e);
     } else if (GeneratorProjectNotExistentException.class.isAssignableFrom(e.getClass())) {
       LOG.error(

--- a/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/healthcheck/HealthCheckDialog.java
+++ b/cobigen-eclipse/cobigen-eclipse/src/com/devonfw/cobigen/eclipse/healthcheck/HealthCheckDialog.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import com.devonfw.cobigen.api.HealthCheck;
 import com.devonfw.cobigen.api.constants.BackupPolicy;
 import com.devonfw.cobigen.api.constants.ConfigurationConstants;
+import com.devonfw.cobigen.api.exception.ConfigurationConflictException;
 import com.devonfw.cobigen.api.exception.InvalidConfigurationException;
 import com.devonfw.cobigen.api.to.HealthCheckReport;
 import com.devonfw.cobigen.api.util.CobiGenPaths;
@@ -106,6 +107,11 @@ public class HealthCheckDialog {
           + "=> Please import the configuration project into your workspace as stated in the "
           + "documentation of CobiGen or in the one of your project.";
       PlatformUIUtil.openErrorDialog(healthyCheckMessage, null);
+    } catch (ConfigurationConflictException e) {
+      healthyCheckMessage = "An unexpected error occurred! Templates were in a conflicted state.";
+      healthyCheckMessage += "\n\nNo automatic upgrade of the context configuration possible.";
+      PlatformUIUtil.openErrorDialog(healthyCheckMessage, e);
+      LOG.error(healthyCheckMessage, e);
     } catch (InvalidConfigurationException e) {
       // Won't be reached anymore
       healthyCheckMessage = firstStep + "OK.";
@@ -226,7 +232,7 @@ public class HealthCheckDialog {
 
   /**
    * Performs a HealthCheckReport on CobiGen_Templates in workspace or on latest templates jar.
-   * 
+   *
    * @return HealthCheckReport the {@link HealthCheckReport} created by the HealthCheck
    * @throws GeneratorProjectNotExistentException if no generator configuration project called
    * @throws CoreException if an existing generator configuration project could not be opened

--- a/cobigen/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/exception/ConfigurationConflictException.java
+++ b/cobigen/cobigen-core-api/src/main/java/com/devonfw/cobigen/api/exception/ConfigurationConflictException.java
@@ -1,0 +1,23 @@
+package com.devonfw.cobigen.api.exception;
+
+import java.nio.file.Path;
+
+/** Occurs if a conflict between the configuration was found */
+public class ConfigurationConflictException extends InvalidConfigurationException {
+
+  /** Default serial version UID */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates a new {@link ConfigurationConflictException} with the given message
+   *
+   * @param filePath file path causing the ConfigurationConflictException or null if not available
+   * @param msg error message of the exception
+   * @param t cause exception
+   */
+  public ConfigurationConflictException(Path filePath, String msg) {
+
+    super(filePath, msg);
+  }
+
+}

--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/ContextConfigurationReader.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/ContextConfigurationReader.java
@@ -22,6 +22,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import com.devonfw.cobigen.api.constants.ConfigurationConstants;
+import com.devonfw.cobigen.api.exception.ConfigurationConflictException;
 import com.devonfw.cobigen.api.exception.InvalidConfigurationException;
 import com.devonfw.cobigen.api.util.ExceptionUtil;
 import com.devonfw.cobigen.api.util.JvmUtil;
@@ -111,7 +112,7 @@ public class ContextConfigurationReader {
   private void checkForConflict(Path configRoot, Path contextFile) {
 
     if (!loadContextFilesInSubfolder(configRoot).isEmpty())
-      throw new InvalidConfigurationException(contextFile,
+      throw new ConfigurationConflictException(contextFile,
           "You are using an old configuration of the templates in addition to new ones. Please make sure this is not the case as both at the same time are not supported. For more details visit this wiki page: "
               + WikiConstants.WIKI_UPDATE_OLD_CONFIG);
   }

--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/ContextConfigurationReader.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/reader/ContextConfigurationReader.java
@@ -18,6 +18,8 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -55,6 +57,9 @@ public class ContextConfigurationReader {
 
   /** Root of the context configuration file, used for passing to ContextConfiguration */
   private Path contextRoot;
+
+  /** Logger instance. */
+  private static final Logger LOG = LoggerFactory.getLogger(ContextConfigurationReader.class);
 
   /**
    * Creates a new instance of the {@link ContextConfigurationReader} which initially parses the given context file
@@ -104,17 +109,21 @@ public class ContextConfigurationReader {
   }
 
   /**
-   * Checks if conflict with old and modular configuration exists
+   * Checks if a conflict with the old and modular configuration exists
    *
    * @param configRoot Path to root directory of the configuration
    * @param contextFile Path to context file of the configuration
    */
   private void checkForConflict(Path configRoot, Path contextFile) {
 
-    if (!loadContextFilesInSubfolder(configRoot).isEmpty())
-      throw new ConfigurationConflictException(contextFile,
-          "You are using an old configuration of the templates in addition to new ones. Please make sure this is not the case as both at the same time are not supported. For more details visit this wiki page: "
-              + WikiConstants.WIKI_UPDATE_OLD_CONFIG);
+    if (!loadContextFilesInSubfolder(configRoot).isEmpty()) {
+      String message = "You are using an old configuration of the templates in addition to new ones. Please make sure this is not the case as both at the same time are not supported. For more details visit this wiki page: "
+          + WikiConstants.WIKI_UPDATE_OLD_CONFIG;
+      ConfigurationConflictException exception = new ConfigurationConflictException(contextFile, message);
+      LOG.error("A conflict with the old and modular configuration exists", exception);
+      throw exception;
+    }
+
   }
 
   /**

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
@@ -3,7 +3,6 @@ package com.devonfw.cobigen.unittest.config.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import java.io.File;
 import java.nio.file.Paths;
 
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   @Test(expected = InvalidConfigurationException.class)
   public void testErrorOnInvalidConfiguration() throws InvalidConfigurationException {
 
-    new ContextConfigurationReader(Paths.get(new File(testFileRootPath + "faulty").toURI()));
+    new ContextConfigurationReader(Paths.get(testFileRootPath + "faulty"));
   }
 
   /**
@@ -52,7 +51,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   public void testConflictConfiguration() throws ConfigurationConflictException {
 
     Throwable bothPresent = assertThrows(ConfigurationConflictException.class, () -> {
-      new ContextConfigurationReader(Paths.get(new File(testFileRootPath + "invalid_new").toURI()));
+      new ContextConfigurationReader(Paths.get(testFileRootPath + "invalid_new"));
     });
 
     assertThat(bothPresent instanceof ConfigurationConflictException);
@@ -67,7 +66,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   @Test
   public void testContextLoadedFromNewConfiguration() throws Exception {
 
-    CobiGenFactory.create(new File(testFileRootPath + "valid_new").toURI());
+    CobiGenFactory.create(Paths.get(testFileRootPath + "valid_new").toUri());
   }
 
   /**
@@ -77,8 +76,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   @Test
   public void testNewConfiguration() {
 
-    ContextConfigurationReader context = new ContextConfigurationReader(
-        Paths.get(new File(testFileRootPath + "valid_new").toURI()));
+    ContextConfigurationReader context = new ContextConfigurationReader(Paths.get(testFileRootPath + "valid_new"));
     assertThat(context.getContextFiles().size()).isEqualTo(2);
   }
 
@@ -92,7 +90,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   @Test
   public void testContextLoadedFromOldConfiguration() throws Exception {
 
-    CobiGenFactory.create(new File(testFileRootPath + "valid_source_folder").toURI());
+    CobiGenFactory.create(Paths.get(testFileRootPath + "valid_source_folder").toUri());
   }
 
   /**
@@ -105,7 +103,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   public void testOldConfiguration() {
 
     ContextConfigurationReader context = new ContextConfigurationReader(
-        Paths.get(new File(testFileRootPath + "valid_source_folder").toURI()));
+        Paths.get(testFileRootPath + "valid_source_folder"));
     assertThat(context.getContextFiles().size()).isEqualTo(1);
   }
 
@@ -117,7 +115,7 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   @Test
   public void testReadConfigurationFromZip() throws Exception {
 
-    CobiGenFactory.create(new File(testFileRootPath + "valid.zip").toURI());
+    CobiGenFactory.create(Paths.get(testFileRootPath + "valid.zip").toUri());
   }
 
 }

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 
+import com.devonfw.cobigen.api.exception.ConfigurationConflictException;
 import com.devonfw.cobigen.api.exception.InvalidConfigurationException;
 import com.devonfw.cobigen.impl.CobiGenFactory;
 import com.devonfw.cobigen.impl.config.constant.WikiConstants;
@@ -38,23 +39,23 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   }
 
   /**
-   * Tests whether an {@link InvalidConfigurationException} will be thrown when both a v2.1 and v2.2 context.xml are
+   * Tests whether an {@link ConfigurationConflictException} will be thrown when both a v2.1 and v2.2 context.xml are
    * present (new templates with old custom templates). Also tests if the thrown error message contains a link to the
    * wiki.
    *
    * Backward Compatibility test, remove when monolithic context.xml is deprecated.
    *
-   * @throws InvalidConfigurationException if a conflict occurred
+   * @throws ConfigurationConflictException if a conflict occurred
    *
    */
   @Test
-  public void testConflictConfiguration() throws InvalidConfigurationException {
+  public void testConflictConfiguration() throws ConfigurationConflictException {
 
-    Throwable bothPresent = assertThrows(InvalidConfigurationException.class, () -> {
+    Throwable bothPresent = assertThrows(ConfigurationConflictException.class, () -> {
       new ContextConfigurationReader(Paths.get(new File(testFileRootPath + "invalid_new").toURI()));
     });
 
-    assertThat(bothPresent instanceof InvalidConfigurationException);
+    assertThat(bothPresent instanceof ConfigurationConflictException);
     assertThat(bothPresent.getMessage()).contains(WikiConstants.WIKI_UPDATE_OLD_CONFIG);
   }
 


### PR DESCRIPTION
Adresses/Fixes #1532.

Implements
* added new ConfigurationConflictException
* replaced InvalidConfigurationException with ConfigurationConflictException in checkForConflict method
* replaced InvalidConfigurationException with ConfigurationConflictException in testConflictConfiguration test
* added new case for conflicted configurations to ExceptionHandler handle method
* added catch of ConfigurationConflictException with adjusted message to healthCheckDialog execute
* added new log error to ContextConfigurationReader checkForConflict

@devonfw/cobigen
