### PR TITLE
 Upgrade picocli to prevent UnsupportedCharsetException #1591.

### DIFF
--- a/cobigen-cli/cli/pom.xml
+++ b/cobigen-cli/cli/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>4.6.2</version>
+      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Adresses/Fixes #1591.

Implements

 * Upgrade picocli version to 4.7.0

@devonfw/cobigen
